### PR TITLE
Propagate MT5 errors

### DIFF
--- a/pipelines/01_capture/utils/exceptions.py
+++ b/pipelines/01_capture/utils/exceptions.py
@@ -1,0 +1,6 @@
+class MT5InitializationError(Exception):
+    """Raised when MetaTrader5 fails to initialize or symbol is unavailable."""
+
+class DataRetrievalError(Exception):
+    """Raised when no data could be retrieved from MetaTrader5."""
+


### PR DESCRIPTION
## Summary
- add specific MT5 exception classes
- raise `MT5InitializationError` and `DataRetrievalError` in capture engine and connector
- capture subprocess output in `run_command` and record specific failures

## Testing
- `python -m py_compile run.py`
- `python -m py_compile pipelines/01_capture/data/connectors/mt5_connector.py pipelines/01_capture/data/capture/hpc_capture.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686ea049bf44832ba7450393ff723805