### PR TITLE
Fix checklist method call

### DIFF
--- a/pipelines/02_validate/reports/quality_reporter.py
+++ b/pipelines/02_validate/reports/quality_reporter.py
@@ -244,7 +244,7 @@ class QualityReporter:
         
         return recommendations
     
-    def generate_checklist(self, df: pd.DataFrame) -> Dict:
+    def _generate_checklist(self, df: pd.DataFrame) -> Dict:
         """
         Generar checklist de calidad detallado
         


### PR DESCRIPTION
## Summary
- rename `generate_checklist` to `_generate_checklist` in `quality_reporter`
- keep call site to avoid AttributeError when generating a quality report

## Testing
- `python test_pipeline.py`
- `python test_enhanced_quality.py` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_686ea8609d70832bb7b468e59ebed951