### PR TITLE
Fix report generation

### DIFF
--- a/pipelines/02_validate/main.py
+++ b/pipelines/02_validate/main.py
@@ -444,7 +444,7 @@ class ValidationPipeline:
         """Generar reporte básico"""
         logger.info("Generando reporte básico...")
         
-        report = self.reporter.generate_report(df)
+        report = self.reporter.generate_quality_report(self.validation_results)
         return report
     
     def _generate_advanced_reports(self, df: pd.DataFrame, analysis: Dict, quality_report: Dict, output_dir: str):


### PR DESCRIPTION
## Summary
- use `generate_quality_report` instead of missing `generate_report`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686eac8d71ec832bbcf02c5e51bae4c9