### PR TITLE
Handle new data columns in validation pipeline

### DIFF
--- a/pipelines/02_validate/preprocessing/data_cleaner.py
+++ b/pipelines/02_validate/preprocessing/data_cleaner.py
@@ -50,6 +50,10 @@ class DataCleaner:
             'temporal': {
                 'method': 'none',
                 'outlier_treatment': 'none'
+            },
+            'market_status': {
+                'method': 'forward_fill',
+                'outlier_treatment': 'none'
             }
         }
         
@@ -59,13 +63,15 @@ class DataCleaner:
             'technical_indicators': [
                 'rsi_14', 'rsi_28', 'stochastic_k', 'stochastic_d',
                 'macd', 'macd_signal', 'macd_histogram', 'atr_14',
-                'sma_20', 'sma_20_slope', 'realized_vol_20'
+                'sma_20', 'sma_20_slope', 'realized_vol_20',
+                'cb_level'
             ],
             'volume': ['tick_volume', 'volume_sma_20', 'volume_ratio'],
-            'price': ['open', 'high', 'low', 'close', 'vwap'],
-            'binary': ['doji', 'hammer', 'shooting_star', 
+            'price': ['open', 'high', 'low', 'close', 'vwap', 'adj_factor'],
+            'binary': ['doji', 'hammer', 'shooting_star',
                        'bullish_engulfing', 'bearish_engulfing'],
-            'temporal': ['hour_sin', 'hour_cos', 'minute_sin', 'minute_cos']
+            'temporal': ['hour_sin', 'hour_cos', 'minute_sin', 'minute_cos'],
+            'market_status': ['halt_flag']
         }
         
     def clean_nan_values(self, df: pd.DataFrame) -> Tuple[pd.DataFrame, Dict]:
@@ -337,6 +343,9 @@ class DataCleaner:
         
         # Binarios
         for feature in self.feature_categories.get('binary', []):
+            if feature in df_final.columns:
+                df_final[feature] = df_final[feature].astype(int)
+        for feature in self.feature_categories.get('market_status', []):
             if feature in df_final.columns:
                 df_final[feature] = df_final[feature].astype(int)
         

--- a/pipelines/02_validate/preprocessing/data_normalizer.py
+++ b/pipelines/02_validate/preprocessing/data_normalizer.py
@@ -33,18 +33,18 @@ class DataNormalizer:
         
         # Features por categoría
         self.feature_categories = {
-            'price': ['open', 'high', 'low', 'close', 'vwap'],
-            'volume': ['tick_volume', 'volume_sma_20', 'volume_relative', 
+            'price': ['open', 'high', 'low', 'close', 'vwap', 'adj_factor'],
+            'volume': ['tick_volume', 'volume_sma_20', 'volume_relative',
                       'volume_ratio', 'volume_delta'],
-            'technical_bounded': ['rsi_14', 'rsi_28', 'stochastic_k', 
+            'technical_bounded': ['rsi_14', 'rsi_28', 'stochastic_k',
                                 'stochastic_d', 'percent_r'],
-            'technical_unbounded': ['macd', 'macd_signal', 'macd_histogram', 
-                                  'atr_14', 'bollinger_width'],
+            'technical_unbounded': ['macd', 'macd_signal', 'macd_histogram',
+                                  'atr_14', 'bollinger_width', 'cb_level'],
             'returns': ['log_return', 'return_5m', 'cumulative_return_session'],
             'temporal': ['hour_sin', 'hour_cos', 'minute_sin', 'minute_cos',
                         'dow_sin', 'dow_cos'],
             'binary': ['doji', 'hammer', 'shooting_star', 'bullish_engulfing',
-                      'bearish_engulfing'],
+                      'bearish_engulfing', 'halt_flag'],
             'exclude': ['time', 'symbol', 'data_flag', 'quality_score']
         }
         

--- a/pipelines/02_validate/reports/advanced_reports.py
+++ b/pipelines/02_validate/reports/advanced_reports.py
@@ -34,9 +34,14 @@ def generate_json_report_enhanced(df: pd.DataFrame, analysis: Dict, capture_stat
         'capture_statistics': capture_stats,
         'data_analysis': analysis,
         'quality_metrics': quality_report,
-        'feature_list': [col for col in df.columns if col not in 
-                        ['time', 'open', 'high', 'low', 'close', 'tick_volume', 
+        'feature_list': [col for col in df.columns if col not in
+                        ['time', 'open', 'high', 'low', 'close', 'tick_volume',
                          'spread', 'real_volume', 'data_flag', 'quality_score']],
+        'contextual_info': {
+            'adj_factor_present': 'adj_factor' in df.columns,
+            'cb_level_present': 'cb_level' in df.columns,
+            'halt_flag_present': 'halt_flag' in df.columns
+        },
         'data_quality_summary': {
             'null_counts': df.isnull().sum().to_dict(),
             'data_types': df.dtypes.astype(str).to_dict(),
@@ -186,6 +191,18 @@ def generate_quality_markdown_report(quality_report: Dict, output_path: str,
             source = record.get('source', 'N/A')
             flag = record.get('data_flag', 'N/A')
             md_content.append(f"| {timestamp} | {score:.3f} | {source} | {flag} |")
+        md_content.append("")
+
+    # Sección contextual
+    contextual_cols = ['adj_factor', 'cb_level', 'halt_flag']
+    available = [c for c in contextual_cols if c in df.columns]
+    if available:
+        md_content.append("## 📝 CONTEXTO ADICIONAL")
+        for col in available:
+            if col == 'halt_flag':
+                md_content.append(f"- **{col}:** {df[col].sum()} eventos de halt")
+            else:
+                md_content.append(f"- **{col}:** rango {df[col].min()} - {df[col].max()}")
         md_content.append("")
     
     # Tiempos de ejecución


### PR DESCRIPTION
## Summary
- update DataCleaner to process `adj_factor`, `cb_level` and `halt_flag`
- update DataNormalizer categories for the new columns
- add contextual info for these columns in advanced reports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686eb9895bd8832baa0925ec3ab9cf37